### PR TITLE
Added apikey getter/setter to Metadata class ; interactive queries to set api fields and cache them.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ApiKeys
 api_keys.yaml
+**/.keys.yaml
 data/*
 **/geckodriver.log
 outputs/*

--- a/EDGAR/metadata_manager.py
+++ b/EDGAR/metadata_manager.py
@@ -1,6 +1,8 @@
 
 import os
 import pickle as pkl
+from yaml import load, CLoader as Loader, dump, CDumper as Dumper
+import warnings
 
 
 class metadata_manager(dict):
@@ -13,6 +15,23 @@ class metadata_manager(dict):
         self.meta_dir = os.path.join(self.path, data_dir, 'metadata')
         if not os.path.exists(self.meta_dir):
             os.system('mkdir -p ' + self.meta_dir)
+        
+        # Used by dataloader for API
+        self.keys_path = os.path.join(self.path, data_dir, 'metadata', '.keys.yaml')
+        self.keys = None
+        
+    def load_keys(self):
+
+        if not os.path.exists(self.keys_path):
+            warnings.warn("No .keys.yaml located", RuntimeWarning)
+            self.keys = dict()
+            return;
+        self.keys = load(open(self.keys_path, 'r'), Loader=Loader)
+    
+    def save_keys(self):
+        
+        print(self.keys)
+        dump(self.keys, open(self.keys_path, 'w'), Dumper=Dumper) 
     
     def load_tikr_metadata(self, tikr):
 

--- a/EDGAR/metadata_manager.py
+++ b/EDGAR/metadata_manager.py
@@ -30,7 +30,6 @@ class metadata_manager(dict):
     
     def save_keys(self):
         
-        print(self.keys)
         dump(self.keys, open(self.keys_path, 'w'), Dumper=Dumper) 
     
     def load_tikr_metadata(self, tikr):

--- a/api_keys.yaml
+++ b/api_keys.yaml
@@ -1,4 +1,0 @@
-# The name of the user, institutional affiliation
-edgar_agent: str
-# The email associated with the user (for SEC to contact them if issues arise) 
-edgar_email: str

--- a/examples/process_nflx.py
+++ b/examples/process_nflx.py
@@ -1,5 +1,5 @@
-import datetime
 import time
+import os
 import sys; sys.path.append('../')
 
 


### PR DESCRIPTION
Removed api_keys.yaml from directory. Instead of requiring new users to set fields, now the dataloader class provides interactive queries to fill the missing fields then caches them. The cached result is saved and also ignored by git.